### PR TITLE
Several smaller fixes, and some changes to make the event calendar more responsive to display sizes

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">

--- a/WebsiteBuilder/src/css/styles.css
+++ b/WebsiteBuilder/src/css/styles.css
@@ -137,6 +137,7 @@ a {
 .logo {
   height: 15em;
   width: 90%;
+  margin: auto;
 
   background-image: url("../images/logotype\ textwhite.png");
   background-size: contain;

--- a/WebsiteBuilder/src/css/styles.css
+++ b/WebsiteBuilder/src/css/styles.css
@@ -653,8 +653,21 @@ body { font: 1em sans-serif;}
 .calendarWrapper {
   overflow-x: hidden;
   overflow-y: hidden;
-  white-space: nowrap;
+  /*white-space: nowrap;*/
   max-width: 100%;
+}
+/* Make calendar screen size responsive */
+@media only screen and (min-width: 600px){
+  .calendarWrapper{
+    padding-left: 2%;
+    padding-right: 2%;
+    width: 96%;
+  }
+}
+@media only screen and (max-width: 600px){
+  .calendarWrapper{
+    width: 100%;
+  }
 }
 
 .calendarInnerWrapper {
@@ -705,6 +718,14 @@ body { font: 1em sans-serif;}
     [end-row];
 }
 
+/* Mobile friendly formatting */
+@media only screen and (max-width: 600px){
+  .weekly-byhour {
+    grid-template-columns: 
+    [time] auto [thu] 1fr [fri] 1.5fr [fri2] 0.75fr [sat] 1fr [sun] 1fr [end-col];
+  }
+}
+
 /* GENERAL ITEM SETUP */
 .calendar li {
   /* background-color: var(--Cp2); */
@@ -733,7 +754,7 @@ li.event {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  text-wrap: nowrap;
+  /*text-wrap: nowrap;*/
   overflow: hidden;
   
   border-radius:5px;
@@ -765,7 +786,10 @@ li.event {
   font-family: "louis_george_caferegularLight";
   font-size: 0.9em;
   flex-grow: 1;
-  overflow:hidden;
+/*  overflow:hidden;*/
+  padding-left: 0.1em;
+  padding-right: 0.1em;
+  text-align: center;
 }
 
 /* DAY HEADINGS   row / col */

--- a/WebsiteBuilder/src/css/styles.css
+++ b/WebsiteBuilder/src/css/styles.css
@@ -56,6 +56,11 @@ html {
 
   font-family: "louis_george_caferegularRegular";
   font-size: 1em;
+
+  /*Stop overscrolling from showing white background*/
+  background-color: #2e0140;
+  overscroll-behavior:contain ;
+
 }
 
 body {

--- a/WebsiteBuilder/src/css/styles.css
+++ b/WebsiteBuilder/src/css/styles.css
@@ -58,8 +58,8 @@ html {
   font-size: 1em;
 
   /*Stop overscrolling from showing white background*/
-  background-color: #2e0140;
-  overscroll-behavior:contain ;
+  /*background-color: #2e0140;
+  overscroll-behavior:contain ;*/ 
 
 }
 

--- a/WebsiteBuilder/src/pages/events.html
+++ b/WebsiteBuilder/src/pages/events.html
@@ -262,32 +262,32 @@
         <div class="bread">
           <div class="textblock">After a long night of dancing and partying, it’s nice to relax and recuperate. At The
             Well warm pools, jacuzzis, steam bath and other wellness attractions awaits your sore muscles and aching
-            heads.</a>
-            <div class="textblock">This is not an 'official' event, and tickets cannot be bought through Pawske Party.
-              We're happy to coordinate a group of those who want to go to the well together and enjoy a Spa day there.
-              Please be aware that you have to buy your ticket for The Well separately.</a>
-              <div class="textblock">The Well is the biggest spa center in the Nordic region and offers a wide array of
-                things to do, including various wellness rituals that are included in the ticket. On their website you
-                can also add up-charges like a massage or various skin treatments. We recommend you check out their <a
-                  href="https://thewell.no/en/">website</a> for all they have to offer.</a>
-                <div class="textblock">At The Well you are free to choose between being naked and wearing swimming
-                  clothes. Saunas can only be used naked. You are only allowed to wear The Well’s own brand that can be
-                  bought in the reception upon arrival.</a>
-                  <div class="textblock">The Well is located a bit outside of Oslo and is accessed by car or bus. There
-                    will not be an organized travel out to the center, but it is easy to find. The Well is located at
-                    Kongeveien 65, 1412 Sofiemyr and has its own parking lot. From Jernbanetorget in Oslo you can take
-                    bus 81 towards Myrvoll Stasjon to Granholtet. Find your best route on <a
-                      href="https://entur.no/">EnTur</a> or through Google.</a>
-                    <div class="textblock">We’ll gather by the front entrance sunday 20.4. at 12:00. Keep in mind that
-                      you can essentially come and go as you please, as this is just a group coordination offer.</a>
-                      <div class="textblock">For more details and the prices check <a href="https://thewell.no/en/">The
-                          Well's Website</a>.</div>
-                    </div>
-                  </div>
+            heads.</div>
+          <div class="textblock">This is not an 'official' event, and tickets cannot be bought through Pawske Party.
+            We're happy to coordinate a group of those who want to go to the well together and enjoy a Spa day there.
+            Please be aware that you have to buy your ticket for The Well separately.</div>
+          <div class="textblock">The Well is the biggest spa center in the Nordic region and offers a wide array of
+            things to do, including various wellness rituals that are included in the ticket. On their website you
+            can also add up-charges like a massage or various skin treatments. We recommend you check out their <a
+              href="https://thewell.no/en/">website</a> for all they have to offer.</div>
+          <div class="textblock">At The Well you are free to choose between being naked and wearing swimming
+            clothes. Saunas can only be used naked. You are only allowed to wear The Well’s own brand that can be
+            bought in the reception upon arrival.</div>
+          <div class="textblock">The Well is located a bit outside of Oslo and is accessed by car or bus. There
+            will not be an organized travel out to the center, but it is easy to find. The Well is located at
+            Kongeveien 65, 1412 Sofiemyr and has its own parking lot. From Jernbanetorget in Oslo you can take
+            bus 81 towards Myrvoll Stasjon to Granholtet. Find your best route on <a href="https://entur.no/">EnTur</a>
+            or through Google.</div>
+          <div class="textblock">We’ll gather by the front entrance sunday 20.4. at 12:00. Keep in mind that
+            you can essentially come and go as you please, as this is just a group coordination offer.</div>
+          <div class="textblock">For more details and the prices check <a href="https://thewell.no/en/">The
+              Well's Website</a>.</div>
+        </div>
+      </div>
 
-                </div>
-                {{-partial "footer.html"-}}
-              </div>
+    </div>
+    {{-partial "footer.html"-}}
+  </div>
 </body>
 
 </html>

--- a/WebsiteBuilder/src/pages/events.html
+++ b/WebsiteBuilder/src/pages/events.html
@@ -62,13 +62,13 @@
               <li class="event outside" style="grid-column: thu;   grid-row: h11/h14;  ">
                 <div class="eventTimeslot">11:00</div>  
                 <div class="eventTitle">City walk</div>
-                <div class="eventinfo">📍 <br> Vinkelplassen</div>
+                <div class="eventinfo">📍 Vinkel&shy;plassen </div>
               </li>
     
               <li class="event outside" style="grid-column: thu;   grid-row: h17/h20 ;  ">
                 <div class="eventTimeslot">17:00</div>  
                 <div class="eventTitle">Bowling</div>
-                <div class="eventinfo">📍 Bowl Veitvet </div>
+                <div class="eventinfo">📍 Lucky Bowl Veitvet </div>
               </li>
     
               <li class="event" style="grid-column: fri;   grid-row: h10/h11;  ">
@@ -133,20 +133,20 @@
               
               <li class="event" style="grid-column: fri2;   grid-row: h1130/h16;">
                 <div class="eventTimeslot">11:45</div>
-                <div class="eventTitle">Dealers <br>Den</div>
+                <div class="eventTitle">Dealers <wbr>Den</div>
                 <!-- <div class="eventinfo"> </div>   -->
               </li>
     
               <li class="event outside" style="grid-column: sat;   grid-row: h16/h19;">
                 <div class="eventTimeslot">16:00</div>
                 <div class="eventTitle">Dead Dog <br> Afternoon</div>
-                <div class="eventinfo">📍Vippa <br>Street Food </div>  
+                <div class="eventinfo">📍 Vippa <wbr>Street&nbsp;Food </div>
               </li>
     
               <li class="event outside" style="grid-column: sun;   grid-row: h12/h20;">
                 <div class="eventTimeslot">12:00</div>
                 <div class="eventTitle"> Post-Party <br> Spa Day </div>
-                <div class="eventinfo">📍The Well </div>  
+                <div class="eventinfo">📍 The Well </div>
               </li>
             </ul>
           </div>

--- a/WebsiteBuilder/src/partials/head.html
+++ b/WebsiteBuilder/src/partials/head.html
@@ -2,6 +2,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">

--- a/applications.html
+++ b/applications.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">

--- a/css/styles.css
+++ b/css/styles.css
@@ -137,6 +137,7 @@ a {
 .logo {
   height: 15em;
   width: 90%;
+  margin: auto;
 
   background-image: url("../images/logotype\ textwhite.png");
   background-size: contain;

--- a/css/styles.css
+++ b/css/styles.css
@@ -653,8 +653,21 @@ body { font: 1em sans-serif;}
 .calendarWrapper {
   overflow-x: hidden;
   overflow-y: hidden;
-  white-space: nowrap;
+  /*white-space: nowrap;*/
   max-width: 100%;
+}
+/* Make calendar screen size responsive */
+@media only screen and (min-width: 600px){
+  .calendarWrapper{
+    padding-left: 2%;
+    padding-right: 2%;
+    width: 96%;
+  }
+}
+@media only screen and (max-width: 600px){
+  .calendarWrapper{
+    width: 100%;
+  }
 }
 
 .calendarInnerWrapper {
@@ -705,6 +718,14 @@ body { font: 1em sans-serif;}
     [end-row];
 }
 
+/* Mobile friendly formatting */
+@media only screen and (max-width: 600px){
+  .weekly-byhour {
+    grid-template-columns: 
+    [time] auto [thu] 1fr [fri] 1.5fr [fri2] 0.75fr [sat] 1fr [sun] 1fr [end-col];
+  }
+}
+
 /* GENERAL ITEM SETUP */
 .calendar li {
   /* background-color: var(--Cp2); */
@@ -733,7 +754,7 @@ li.event {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  text-wrap: nowrap;
+  /*text-wrap: nowrap;*/
   overflow: hidden;
   
   border-radius:5px;
@@ -765,7 +786,10 @@ li.event {
   font-family: "louis_george_caferegularLight";
   font-size: 0.9em;
   flex-grow: 1;
-  overflow:hidden;
+/*  overflow:hidden;*/
+  padding-left: 0.1em;
+  padding-right: 0.1em;
+  text-align: center;
 }
 
 /* DAY HEADINGS   row / col */

--- a/css/styles.css
+++ b/css/styles.css
@@ -56,6 +56,11 @@ html {
 
   font-family: "louis_george_caferegularRegular";
   font-size: 1em;
+
+  /*Stop overscrolling from showing white background*/
+  background-color: #2e0140;
+  overscroll-behavior:contain ;
+
 }
 
 body {

--- a/events.html
+++ b/events.html
@@ -314,31 +314,31 @@
         <div class="bread">
           <div class="textblock">After a long night of dancing and partying, it’s nice to relax and recuperate. At The
             Well warm pools, jacuzzis, steam bath and other wellness attractions awaits your sore muscles and aching
-            heads.</a>
-            <div class="textblock">This is not an 'official' event, and tickets cannot be bought through Pawske Party.
-              We're happy to coordinate a group of those who want to go to the well together and enjoy a Spa day there.
-              Please be aware that you have to buy your ticket for The Well separately.</a>
-              <div class="textblock">The Well is the biggest spa center in the Nordic region and offers a wide array of
-                things to do, including various wellness rituals that are included in the ticket. On their website you
-                can also add up-charges like a massage or various skin treatments. We recommend you check out their <a
-                  href="https://thewell.no/en/">website</a> for all they have to offer.</a>
-                <div class="textblock">At The Well you are free to choose between being naked and wearing swimming
-                  clothes. Saunas can only be used naked. You are only allowed to wear The Well’s own brand that can be
-                  bought in the reception upon arrival.</a>
-                  <div class="textblock">The Well is located a bit outside of Oslo and is accessed by car or bus. There
-                    will not be an organized travel out to the center, but it is easy to find. The Well is located at
-                    Kongeveien 65, 1412 Sofiemyr and has its own parking lot. From Jernbanetorget in Oslo you can take
-                    bus 81 towards Myrvoll Stasjon to Granholtet. Find your best route on <a
-                      href="https://entur.no/">EnTur</a> or through Google.</a>
-                    <div class="textblock">We’ll gather by the front entrance sunday 20.4. at 12:00. Keep in mind that
-                      you can essentially come and go as you please, as this is just a group coordination offer.</a>
-                      <div class="textblock">For more details and the prices check <a href="https://thewell.no/en/">The
-                          Well's Website</a>.</div>
-                    </div>
-                  </div>
+            heads.</div>
+          <div class="textblock">This is not an 'official' event, and tickets cannot be bought through Pawske Party.
+            We're happy to coordinate a group of those who want to go to the well together and enjoy a Spa day there.
+            Please be aware that you have to buy your ticket for The Well separately.</div>
+          <div class="textblock">The Well is the biggest spa center in the Nordic region and offers a wide array of
+            things to do, including various wellness rituals that are included in the ticket. On their website you
+            can also add up-charges like a massage or various skin treatments. We recommend you check out their <a
+              href="https://thewell.no/en/">website</a> for all they have to offer.</div>
+          <div class="textblock">At The Well you are free to choose between being naked and wearing swimming
+            clothes. Saunas can only be used naked. You are only allowed to wear The Well’s own brand that can be
+            bought in the reception upon arrival.</div>
+          <div class="textblock">The Well is located a bit outside of Oslo and is accessed by car or bus. There
+            will not be an organized travel out to the center, but it is easy to find. The Well is located at
+            Kongeveien 65, 1412 Sofiemyr and has its own parking lot. From Jernbanetorget in Oslo you can take
+            bus 81 towards Myrvoll Stasjon to Granholtet. Find your best route on <a href="https://entur.no/">EnTur</a>
+            or through Google.</div>
+          <div class="textblock">We’ll gather by the front entrance sunday 20.4. at 12:00. Keep in mind that
+            you can essentially come and go as you please, as this is just a group coordination offer.</div>
+          <div class="textblock">For more details and the prices check <a href="https://thewell.no/en/">The
+              Well's Website</a>.</div>
+        </div>
+      </div>
 
-                </div>
-                <footer>
+    </div>
+    <footer>
     <div class="about">
         Pawske party © 2023-2025 <br>
         orgnr: 930 235 490
@@ -357,7 +357,7 @@
         </div>
     </div>
 </footer>
-              </div>
+  </div>
 </body>
 
 </html>

--- a/events.html
+++ b/events.html
@@ -114,13 +114,13 @@
               <li class="event outside" style="grid-column: thu;   grid-row: h11/h14;  ">
                 <div class="eventTimeslot">11:00</div>  
                 <div class="eventTitle">City walk</div>
-                <div class="eventinfo">📍 <br> Vinkelplassen</div>
+                <div class="eventinfo">📍 Vinkel&shy;plassen </div>
               </li>
     
               <li class="event outside" style="grid-column: thu;   grid-row: h17/h20 ;  ">
                 <div class="eventTimeslot">17:00</div>  
                 <div class="eventTitle">Bowling</div>
-                <div class="eventinfo">📍 Bowl Veitvet </div>
+                <div class="eventinfo">📍 Lucky Bowl Veitvet </div>
               </li>
     
               <li class="event" style="grid-column: fri;   grid-row: h10/h11;  ">
@@ -185,20 +185,20 @@
               
               <li class="event" style="grid-column: fri2;   grid-row: h1130/h16;">
                 <div class="eventTimeslot">11:45</div>
-                <div class="eventTitle">Dealers <br>Den</div>
+                <div class="eventTitle">Dealers <wbr>Den</div>
                 <!-- <div class="eventinfo"> </div>   -->
               </li>
     
               <li class="event outside" style="grid-column: sat;   grid-row: h16/h19;">
                 <div class="eventTimeslot">16:00</div>
                 <div class="eventTitle">Dead Dog <br> Afternoon</div>
-                <div class="eventinfo">📍Vippa <br>Street Food </div>  
+                <div class="eventinfo">📍 Vippa <wbr>Street&nbsp;Food </div>
               </li>
     
               <li class="event outside" style="grid-column: sun;   grid-row: h12/h20;">
                 <div class="eventTimeslot">12:00</div>
                 <div class="eventTitle"> Post-Party <br> Spa Day </div>
-                <div class="eventinfo">📍The Well </div>  
+                <div class="eventinfo">📍 The Well </div>
               </li>
             </ul>
           </div>

--- a/events.html
+++ b/events.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">

--- a/faq.html
+++ b/faq.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">

--- a/gallery.html
+++ b/gallery.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">

--- a/team.html
+++ b/team.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">

--- a/tickets.html
+++ b/tickets.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">

--- a/tosncoc.html
+++ b/tosncoc.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!-- Add theme color meta for browsers that use this for browser styling -->
+	<meta name="theme-color" content="#2e0140">
 
 	<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">


### PR DESCRIPTION
Mainly this was supposed to just fix the small irk I had about the calendar being weirdly sized on PC....

Well, the result is as follows:
# Visuals
## Calendar 
Some fairly big changes to the event calendar:
### Desktop 
The calendar will be the same width as the rest of the main content on the page, giving more horizontal space per event for text.
(And making the page layout more consistent)
### Mobile
The dealers den event will become slightly less wide to conserve space, and location names are now more consistent in how they hande line breaks (on mobile, "bowl veitvet" and "Vinkelplassen" went off the edge of the event-box)
## "Overscroll" and theme tagging
### Overscroll 

> Edit: Did an oops, this is commented out for now as it broke PC version [7724844](https://github.com/AuThrykki/PawskeParty/pull/7/commits/7724844eccc4b68e99b1025ab8b2f90619796f24)

~~On mobile you would get a white background if you scrolled past the edge of the page, since `background-image` doesn't work on the mobile overscroll function/animation
I've therefore defined `background-color`, so the overscroll at least isn't bright white and as noticable.~~
### Theme tagging
The tag `<meta name="theme-color" content="#2e0140">` simply supplies browsers with a theme color for the page, as some browsers (such as Safari on iOS) uses this to change the color of the URL bar, navigation buttons, the tab itself etc.
Completely unnecessary, but why not.
# Small fixes
## Tag-fixes
Finally, I noticed a bunch of `<div>` tags closed with `</a>` instead of `</div>`, so I went ahead and fixed this.

Been a while since I've worked with WebDev stuff, so although I've tested my changes as much as I can, there might be something I've missed 😄 